### PR TITLE
issue #49 link project video to https link

### DIFF
--- a/src/components/projects/Projects.tsx
+++ b/src/components/projects/Projects.tsx
@@ -18,7 +18,7 @@ const Projects = () => {
     {
       key: 'brain-vis1',
       video: true,
-      path: '/projects/brain-vis.mp4',
+      path: 'https://raw.githubusercontent.com/moonbuild/portfolio/main/public/projects/brain-vis.mp4',
       title: 'Brain Visualisation',
       description: `
       This web application is helps neuroscientists and researchers visualize EEG data as Topomaps, PSD Plots and many such visualisations.


### PR DESCRIPTION
This PR is linked to #49 

In this PR I worked on:- 
1. Instead of linking to relative file path for Project video, I linked via web link via `raw.githubusercontent` .